### PR TITLE
array_map: direct invocation is faster

### DIFF
--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -204,8 +204,6 @@ function baz($options)
     {
         $definedFunctions = \get_defined_functions();
 
-        return \array_map(function ($name) {
-            return \strtolower($name);
-        }, $definedFunctions['internal']);
+        return \array_map('strtolower', $definedFunctions['internal']);
     }
 }


### PR DESCRIPTION
```
$ time php -r '$a=\get_defined_functions();for($i=1;$i<50000;++$i){\array_map(function($n){return \strtolower($n);},$a["internal"]);}'

real    0m7.507s
user    0m7.492s
sys     0m0.004s

$ time php -r '$a=\get_defined_functions();for($i=1;$i<50000;++$i){\array_map("strtolower",$a["internal"]);}'

real    0m5.336s
user    0m5.324s
sys     0m0.004s
```